### PR TITLE
Clarify documentation around secure password handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,19 @@
 
 __This is designed to run with Buildkite Agent v3.x beta. Plugins are not yet supported in Buildkite Agent v2.x.__
 
-Login to docker registries. 
+Login to docker registries.
 
-## Example
+## Securing your password
 
-This will log in to Docker Hub prior to running your build step.
+To avoid leaking your docker password to buildkite.com or anyone with access to build logs, you need to avoid including it in pipeline.yml. This means it needs to be set specifically with an environment variable in an [Agent hook](https://buildkite.com/docs/agent/hooks), for instance the environment hook.
+
+The examples below show how to provide passwords for single and multiple registries.
+
+## Example: Login to docker hub (or a single server)
+
+```bash
+export BUILDKITE_PLUGIN_DOCKER_LOGIN_PASSWORD=mysecretpassword
+```
 
 ```yml
 steps:
@@ -14,22 +22,24 @@ steps:
     plugins:
       docker-login#v1.0.0:
         username: myuser
-        password: ${PASSWORD_FROM_ENV}
 ```
 
-You can login to multiple registries if required:
+## Example: Log in to multiple registries
+
+```bash
+export BUILDKITE_PLUGIN_DOCKER_LOGIN_PASSWORD_0=mysecretpassword1
+export BUILDKITE_PLUGIN_DOCKER_LOGIN_PASSWORD_1=mysecretpassword2
+```
 
 ```yml
 steps:
   - command: ./run_build.sh
     plugins:
       docker-login#v1.0.0:
-        - server: my.private.registry 
+        - server: my.private.registry
           username: myuser
-          password: ${PASSWORD_FROM_ENV}
-        - server: another.private.registry 
+        - server: another.private.registry
           username: myuser
-          password: ${PASSWORD_FROM_ENV}
 ```
 
 ## Options
@@ -37,10 +47,6 @@ steps:
 ### `username`
 
 The username to send to the docker registry.
-
-### `password`
-
-The password to send to the docker registry.
 
 ### `server`
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The examples below show how to provide passwords for single and multiple registr
 ## Example: Login to docker hub (or a single server)
 
 ```bash
+# environment or pre-command hook
 export BUILDKITE_PLUGIN_DOCKER_LOGIN_PASSWORD=mysecretpassword
 ```
 
@@ -27,6 +28,7 @@ steps:
 ## Example: Log in to multiple registries
 
 ```bash
+# environment or pre-command hook
 export BUILDKITE_PLUGIN_DOCKER_LOGIN_PASSWORD_0=mysecretpassword1
 export BUILDKITE_PLUGIN_DOCKER_LOGIN_PASSWORD_1=mysecretpassword2
 ```


### PR DESCRIPTION
As raised in #1, it's critical that passwords aren't entered in pipeline.yml.

This clarifies the documentation around this. 

Closes #1.