### PR TITLE
Use `password-env` to access password by env key

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,31 +15,45 @@ The examples below show how to provide passwords for single and multiple registr
 export BUILDKITE_PLUGIN_DOCKER_LOGIN_PASSWORD=mysecretpassword
 ```
 
+To avoid leaking your docker password to buildkite.com or anyone with access to build logs, you need to avoid including it in pipeline.yml. This means it needs to be set specifically with an environment variable in an [Agent hook](https://buildkite.com/docs/agent/hooks), for instance the environment hook.
+
+The examples below show how to provide passwords for single and multiple registries. Note how the `password-env` field refers to the name of the environment var that has the password in it.
+
+## Example: Login to docker hub (or a single server)
+
+```bash
+# environment or pre-command hook
+export DOCKER_LOGIN_PASSWORD=mysecretpassword
+```
+
 ```yml
 steps:
   - command: ./run_build.sh
     plugins:
       docker-login#v1.1.0:
         username: myuser
+        password-env: DOCKER_LOGIN_PASSWORD
 ```
 
 ## Example: Log in to multiple registries
 
 ```bash
 # environment or pre-command hook
-export BUILDKITE_PLUGIN_DOCKER_LOGIN_0_PASSWORD=mysecretpassword1
-export BUILDKITE_PLUGIN_DOCKER_LOGIN_1_PASSWORD=mysecretpassword2
+export DOCKER_LOGIN_MY_PRIVATE_REGISTRY=mysecretpassword1
+export DOCKER_LOGIN_ANOTHER_REGISTRY=mysecretpassword2
 ```
 
 ```yml
 steps:
   - command: ./run_build.sh
     plugins:
-      docker-login#v1.1.0:
+      docker-login#v1.0.0:
         - server: my.private.registry
           username: myuser
+          password-env: DOCKER_LOGIN_MY_PRIVATE_REGISTRY
         - server: another.private.registry
           username: myuser
+          password-env: DOCKER_LOGIN_ANOTHER_REGISTRY
 ```
 
 ## Options
@@ -51,6 +65,12 @@ The username to send to the docker registry.
 ### `server` (optional)
 
 The server to log in to, if blank or ommitted logs into Docker Hub.
+
+### `password-env`
+
+The environment variable that the password is stored in
+
+Defaults to `DOCKER_LOGIN_PASSWORD`.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ export DOCKER_LOGIN_ANOTHER_REGISTRY=mysecretpassword2
 steps:
   - command: ./run_build.sh
     plugins:
-      docker-login#v1.0.0:
+      docker-login#v1.1.0:
         - server: my.private.registry
           username: myuser
           password-env: DOCKER_LOGIN_MY_PRIVATE_REGISTRY

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -10,13 +10,23 @@ function plugin_var_prefixes() {
   done < <(env) | sort | uniq
 }
 
-mapfile -t prefixes < <(plugin_var_prefixes)
-
 # enumerate the list of servers to login
-for prefix in "${prefixes[@]}" ; do
+plugin_var_prefixes | while IFS='=' read -r prefix _ ; do
   username_var="${prefix}_USERNAME"
-  password_var="${prefix}_PASSWORD"
+  password_legacy="${prefix}_PASSWORD"
+  password_env_var="${prefix}_PASSWORD_ENV"
+  password_var="${!password_env_var:-DOCKER_LOGIN_PASSWORD}"
   server_var="${prefix}_SERVER"
+
+  if [[ -n "${!password_legacy:-}" ]] ; then
+    echo "+++ :warn: The password property of the docker-login plugin has been deprecated, use password-env instead"
+    password_var="$password_legacy"
+  fi
+
+  if [[ -z "${!password_var:-}" ]] ; then
+    echo "+++ 🚨 No docker-login password found in \$${password_var}"
+    exit 1
+  fi
 
   login_args=(
     "--username" "${!username_var:-}"

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -38,5 +38,5 @@ plugin_var_prefixes | while IFS='=' read -r prefix _ ; do
   fi
 
   echo "~~~ :docker: Logging into docker registry ${!server_var:-hub.docker.com}"
-  echo "${!password_var:-}" | docker login "${login_args[@]}"
+  docker login "${login_args[@]}" <<< "${!password_var:-}"
 done

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -6,10 +6,10 @@ load '/usr/local/lib/bats/load.bash'
 
 @test "Login to single registry" {
   export BUILDKITE_PLUGIN_DOCKER_LOGIN_USERNAME="blah"
-  export BUILDKITE_PLUGIN_DOCKER_LOGIN_PASSWORD="llamas"
+  export DOCKER_LOGIN_PASSWORD="llamas"
 
   stub docker \
-    "login --username blah --password-stdin : echo logging in to docker hub"
+    "login --username blah --password llamas : echo logging in to docker hub"
 
   run $PWD/hooks/pre-command
 
@@ -19,16 +19,34 @@ load '/usr/local/lib/bats/load.bash'
   unstub docker
 }
 
+@test "Login to single registry with deprecated password" {
+  export BUILDKITE_PLUGIN_DOCKER_LOGIN_USERNAME="blah"
+  export BUILDKITE_PLUGIN_DOCKER_LOGIN_PASSWORD="llamas"
+
+  stub docker \
+    "login --username blah --password-stdin : echo logging in to docker hub"
+
+  run $PWD/hooks/pre-command
+
+  assert_success
+  assert_output --partial "logging in to docker hub"
+  assert_output --partial "The password property of the docker-login plugin has been deprecated"
+
+  unstub docker
+}
+
 @test "Login to multiple registries" {
   export BUILDKITE_PLUGIN_DOCKER_LOGIN_0_USERNAME="blah"
   export BUILDKITE_PLUGIN_DOCKER_LOGIN_0_SERVER="my.registry.blah"
-  export BUILDKITE_PLUGIN_DOCKER_LOGIN_0_PASSWORD="llamas"
+  export BUILDKITE_PLUGIN_DOCKER_LOGIN_0_PASSWORD_ENV="DOCKER_LOGIN_PASSWORD1"
+  export DOCKER_LOGIN_PASSWORD1="llamas"
   export BUILDKITE_PLUGIN_DOCKER_LOGIN_1_USERNAME="blah"
-  export BUILDKITE_PLUGIN_DOCKER_LOGIN_1_PASSWORD="llamas"
+  export BUILDKITE_PLUGIN_DOCKER_LOGIN_1_PASSWORD_ENV="DOCKER_LOGIN_PASSWORD2"
+  export DOCKER_LOGIN_PASSWORD2="alpacas"
 
   stub docker \
-    "login --username blah --password-stdin my.registry.blah : echo logging in to my.registry.blah" \
-    "login --username blah --password-stdin : echo logging in to docker hub"
+    "login --username blah --password-stdin llamas my.registry.blah : echo logging in to my.registry.blah" \
+    "login --username blah --password-stdin alpacas : echo logging in to docker hub"
 
   run $PWD/hooks/pre-command
 

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -9,7 +9,7 @@ load '/usr/local/lib/bats/load.bash'
   export DOCKER_LOGIN_PASSWORD="llamas"
 
   stub docker \
-    "login --username blah --password llamas : echo logging in to docker hub"
+    "login --username blah --password-stdin : echo logging in to docker hub"
 
   run $PWD/hooks/pre-command
 
@@ -45,8 +45,8 @@ load '/usr/local/lib/bats/load.bash'
   export DOCKER_LOGIN_PASSWORD2="alpacas"
 
   stub docker \
-    "login --username blah --password-stdin llamas my.registry.blah : echo logging in to my.registry.blah" \
-    "login --username blah --password-stdin alpacas : echo logging in to docker hub"
+    "login --username blah --password-stdin my.registry.blah : echo logging in to my.registry.blah" \
+    "login --username blah --password-stdin : echo logging in to docker hub"
 
   run $PWD/hooks/pre-command
 


### PR DESCRIPTION
@toolmantim this was my thinking on how to handle the problem of "allow env to be used in plugin configuration without leaking it in pipeline.yml".