### PR TITLE
Revert "Fix bug where env export had trailing \r on windows"

### DIFF
--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -11,7 +11,7 @@ function plugin_var_prefixes() {
 }
 
 # enumerate the list of servers to login
-plugin_var_prefixes | tr -d '\r' | while IFS='=' read -r prefix _ ; do
+plugin_var_prefixes | while IFS='=' read -r prefix _ ; do
   username_var="${prefix}_USERNAME"
   password_legacy="${prefix}_PASSWORD"
   password_env_var="${prefix}_PASSWORD_ENV"


### PR DESCRIPTION
Reverts buildkite-plugins/docker-login-buildkite-plugin#27 as it's more to do with a quirk of the default Git for Windows `$PATH` setup , than a concern of this plugin.