### PR TITLE
Set DOCKER_CONFIG before login

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/.dockerlogin.*

--- a/README.md
+++ b/README.md
@@ -61,6 +61,14 @@ The environment variable that the password is stored in
 
 Defaults to `DOCKER_LOGIN_PASSWORD`.
 
+## Developing
+
+To run the tests:
+
+```sh
+docker-compose run --rm tests
+```
+
 ## License
 
 MIT (see [LICENSE](LICENSE))

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -eu -o pipefail
+
+rm -r "$DOCKER_CONFIG"

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -10,6 +10,10 @@ function plugin_var_prefixes() {
   done < <(env) | sort | uniq
 }
 
+export DOCKER_CONFIG="./.dockerlogin.$$/"
+mkdir -p "$DOCKER_CONFIG"
+echo "{}" > "$DOCKER_CONFIG/config.json"
+
 # enumerate the list of servers to login
 plugin_var_prefixes | while IFS='=' read -r prefix _ ; do
   username_var="${prefix}_USERNAME"

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -56,3 +56,14 @@ load '/usr/local/lib/bats/load.bash'
 
   unstub docker
 }
+
+@test "Cleans up the docker login cache" {
+  mkdir -p 'tests/tmp/.docker-login'
+
+  export DOCKER_CONFIG='tests/tmp/.docker-login'
+
+  run $PWD/hooks/post-command
+
+  assert_success
+  assert [ ! -e 'tests/tmp/.docker-login' ]
+}


### PR DESCRIPTION
This PR changes the `docker login` behaviour so instead of letting Docker cache the login credentials in the default way (`~/.docker/config.json`, which isn't really designed for a CI environment) they're stored in a temporary directory in the local checkout, and then deleted after the command is completed.