### PR TITLE
You can't use an array to configure a plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,13 @@ steps:
   - command: ./run_build.sh
     plugins:
       - docker-login#v2.0.1:
-          - server: my.private.registry
-            username: myuser
-            password-env: DOCKER_LOGIN_MY_PRIVATE_REGISTRY
-          - server: another.private.registry
-            username: myuser
-            password-env: DOCKER_LOGIN_ANOTHER_REGISTRY
+          server: my.private.registry
+          username: myuser
+          password-env: DOCKER_LOGIN_MY_PRIVATE_REGISTRY
+      - docker-login#v2.0.1:
+          server: another.private.registry
+          username: myuser
+          password-env: DOCKER_LOGIN_ANOTHER_REGISTRY
 ```
 
 ## Options


### PR DESCRIPTION
Turns out using arrays for plugin config was never a thing we supported!

Fixes https://github.com/buildkite-plugins/docker-login-buildkite-plugin/issues/40