### PR TITLE
Remove code for logging into multiple registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,13 @@ A [Buildkite plugin](https://buildkite.com/docs/agent/v3/plugins) to login to do
 
 ## Securing your password
 
-To avoid leaking your docker password to buildkite.com or anyone with access to build logs, you need to avoid including it in pipeline.yml. This means it needs to be set specifically with an environment variable in an [Agent hook](https://buildkite.com/docs/agent/hooks), for instance the environment hook.
+To avoid leaking your docker password to buildkite.com or anyone with access to build logs, you need to avoid including it in pipeline.yml. This means it needs to be set specifically with an environment variable in an [Agent hook](https://buildkite.com/docs/agent/hooks), or made available from a previous plugin defined on the same step.
 
-The examples below show how to provide passwords for single and multiple registries.
-
-## Example: Login to docker hub (or a single server)
+## Example
 
 ```bash
 # environment or pre-command hook
-export DOCKER_LOGIN_PASSWORD=mysecretpassword
+export MY_DOCKER_LOGIN_PASSWORD=mysecretpassword
 ```
 
 ```yml
@@ -21,29 +19,7 @@ steps:
     plugins:
       - docker-login#v2.0.1:
           username: myuser
-          password-env: DOCKER_LOGIN_PASSWORD
-```
-
-## Example: Log in to multiple registries
-
-```bash
-# environment or pre-command hook
-export DOCKER_LOGIN_MY_PRIVATE_REGISTRY=mysecretpassword1
-export DOCKER_LOGIN_ANOTHER_REGISTRY=mysecretpassword2
-```
-
-```yml
-steps:
-  - command: ./run_build.sh
-    plugins:
-      - docker-login#v2.0.1:
-          server: my.private.registry
-          username: myuser
-          password-env: DOCKER_LOGIN_MY_PRIVATE_REGISTRY
-      - docker-login#v2.0.1:
-          server: another.private.registry
-          username: myuser
-          password-env: DOCKER_LOGIN_ANOTHER_REGISTRY
+          password-env: MY_DOCKER_LOGIN_PASSWORD
 ```
 
 ## Options
@@ -58,7 +34,7 @@ The server to log in to, if blank or ommitted logs into Docker Hub.
 
 ### `password-env`
 
-The environment variable that the password is stored in
+The environment variable that the password is stored in.
 
 Defaults to `DOCKER_LOGIN_PASSWORD`.
 

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -2,41 +2,21 @@
 
 set -eu -o pipefail
 
-function plugin_var_prefixes() {
-  while IFS='=' read -r name _ ; do
-    if [[ $name =~ ^(BUILDKITE_PLUGIN_DOCKER_LOGIN_[0-9]+) || $name =~ ^(BUILDKITE_PLUGIN_DOCKER_LOGIN)_[^0-9] ]] ; then
-      echo "${BASH_REMATCH[1]}"
-    fi
-  done < <(env) | sort | uniq
-}
+password_var="${BUILDKITE_PLUGIN_DOCKER_LOGIN_PASSWORD_ENV:-DOCKER_LOGIN_PASSWORD}"
 
-# enumerate the list of servers to login
-plugin_var_prefixes | while IFS='=' read -r prefix _ ; do
-  username_var="${prefix}_USERNAME"
-  password_legacy="${prefix}_PASSWORD"
-  password_env_var="${prefix}_PASSWORD_ENV"
-  password_var="${!password_env_var:-DOCKER_LOGIN_PASSWORD}"
-  server_var="${prefix}_SERVER"
+if [[ -z "${!password_var:-}" ]] ; then
+  echo "+++ 🚨 No docker-login password found in \$${password_var}"
+  exit 1
+fi
 
-  if [[ -n "${!password_legacy:-}" ]] ; then
-    echo "+++ :warn: The password property of the docker-login plugin has been deprecated, use password-env instead"
-    password_var="$password_legacy"
-  fi
+login_args=(
+  "--username" "${BUILDKITE_PLUGIN_DOCKER_LOGIN_USERNAME}"
+  "--password-stdin"
+)
 
-  if [[ -z "${!password_var:-}" ]] ; then
-    echo "+++ 🚨 No docker-login password found in \$${password_var}"
-    exit 1
-  fi
+if [[ -n "${BUILDKITE_PLUGIN_DOCKER_LOGIN_SERVER:-}" ]] ; then
+  login_args+=("${BUILDKITE_PLUGIN_DOCKER_LOGIN_SERVER}")
+fi
 
-  login_args=(
-    "--username" "${!username_var:-}"
-    "--password-stdin"
-  )
-
-  if [[ -n "${!server_var:-}" ]] ; then
-    login_args+=("${!server_var:-}")
-  fi
-
-  echo "~~~ :docker: Logging into docker registry ${!server_var:-hub.docker.com}"
-  docker login "${login_args[@]}" <<< "${!password_var:-}"
-done
+echo "~~~ :docker: Logging into docker registry ${BUILDKITE_PLUGIN_DOCKER_LOGIN_SERVER:-}"
+docker login "${login_args[@]}" <<< "${!password_var:-}"

--- a/plugin.yml
+++ b/plugin.yml
@@ -10,5 +10,7 @@ configuration:
       type: string
     server:
       type: string
+    password-env:
+      type: string
   required:
     - username

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -4,7 +4,7 @@ load '/usr/local/lib/bats/load.bash'
 
 # export DOCKER_STUB_DEBUG=/dev/tty
 
-@test "Login to single registry" {
+@test "Login to single registry with default password" {
   export BUILDKITE_PLUGIN_DOCKER_LOGIN_USERNAME="blah"
   export DOCKER_LOGIN_PASSWORD="llamas"
 
@@ -19,9 +19,10 @@ load '/usr/local/lib/bats/load.bash'
   unstub docker
 }
 
-@test "Login to single registry with deprecated password" {
+@test "Login to single registry with password-env" {
   export BUILDKITE_PLUGIN_DOCKER_LOGIN_USERNAME="blah"
-  export BUILDKITE_PLUGIN_DOCKER_LOGIN_PASSWORD="llamas"
+  export BUILDKITE_PLUGIN_DOCKER_LOGIN_PASSWORD_ENV="CUSTOM_DOCKER_LOGIN_PASSWORD"
+  export CUSTOM_DOCKER_LOGIN_PASSWORD="llamas"
 
   stub docker \
     "login --username blah --password-stdin : echo logging in to docker hub"
@@ -29,29 +30,6 @@ load '/usr/local/lib/bats/load.bash'
   run $PWD/hooks/pre-command
 
   assert_success
-  assert_output --partial "logging in to docker hub"
-  assert_output --partial "The password property of the docker-login plugin has been deprecated"
-
-  unstub docker
-}
-
-@test "Login to multiple registries" {
-  export BUILDKITE_PLUGIN_DOCKER_LOGIN_0_USERNAME="blah"
-  export BUILDKITE_PLUGIN_DOCKER_LOGIN_0_SERVER="my.registry.blah"
-  export BUILDKITE_PLUGIN_DOCKER_LOGIN_0_PASSWORD_ENV="DOCKER_LOGIN_PASSWORD1"
-  export DOCKER_LOGIN_PASSWORD1="llamas"
-  export BUILDKITE_PLUGIN_DOCKER_LOGIN_1_USERNAME="blah"
-  export BUILDKITE_PLUGIN_DOCKER_LOGIN_1_PASSWORD_ENV="DOCKER_LOGIN_PASSWORD2"
-  export DOCKER_LOGIN_PASSWORD2="alpacas"
-
-  stub docker \
-    "login --username blah --password-stdin my.registry.blah : echo logging in to my.registry.blah" \
-    "login --username blah --password-stdin : echo logging in to docker hub"
-
-  run $PWD/hooks/pre-command
-
-  assert_success
-  assert_output --partial "logging in to my.registry.blah"
   assert_output --partial "logging in to docker hub"
 
   unstub docker


### PR DESCRIPTION
You could never define multiple Docker registries to log into from your pipeline.yml, and the documentation was removed in #44. This also removes the code, and justifies a major version bump just in case anyone was using it via the environment variables.