### PR TITLE
Add README info about Windows PATH and git-bash to the README, fixes #52

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ The environment variable that the password is stored in.
 
 Defaults to `DOCKER_LOGIN_PASSWORD`.
 
+## Windows Issues
+
+This plugin requires git-bash, not the Windows built-in bash.exe, so you'll need to set your system PATH to have git-bash bin directory first, normallly `C:\Program Files\git\bin`.
+
 ## License
 
 MIT (see [LICENSE](LICENSE))


### PR DESCRIPTION
Add README info about Windows PATH and git-bash to the README, fixes #52

If the Windows-native bash.exe is first in the PATH, this won't work at all.