### PR TITLE
Add retry parameter and function from ecr-buildkite-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ The environment variable that the password is stored in.
 
 Defaults to `DOCKER_LOGIN_PASSWORD`.
 
+### `retries` (optional)
+
+Retries login after a delay N times. Defaults to 0.
+
 ## License
 
 MIT (see [LICENSE](LICENSE))

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -18,5 +18,36 @@ if [[ -n "${BUILDKITE_PLUGIN_DOCKER_LOGIN_SERVER:-}" ]] ; then
   login_args+=("${BUILDKITE_PLUGIN_DOCKER_LOGIN_SERVER}")
 fi
 
+# Retries a command on failure.
+function retry() {
+  local -r -i retries="$1"; shift
+  local -i max_attempts=$((retries + 1))
+  local -i attempt_num=1
+  local exit_code
+  local stdin_value
+
+  if [[ "$1" == "--with-stdin" ]]; then
+    read -sr stdin_value
+    shift
+  fi
+
+  while (( attempt_num <= max_attempts )); do
+    set +e
+    "$@" <<< "${stdin_value:-}"
+    exit_code=$?
+    set -e
+
+    if [[ $retries -eq 0 ]] || [[ $exit_code -eq 0 ]]; then
+      return $exit_code
+    elif (( attempt_num == max_attempts )) ; then
+      echo "Login failed after $attempt_num attempts" >&2
+      return $exit_code
+    else
+      echo "Login failed on attempt ${attempt_num} of ${max_attempts}. Trying again in $attempt_num seconds..." >&2
+      sleep $(( attempt_num++ ))
+    fi
+  done
+}
+
 echo "~~~ :docker: Logging into docker registry ${BUILDKITE_PLUGIN_DOCKER_LOGIN_SERVER:-}"
-docker login "${login_args[@]}" <<< "${!password_var:-}"
+retry "${BUILDKITE_PLUGIN_DOCKER_LOGIN_RETRIES:-0}" --with-stdin docker login "${login_args[@]}" <<< "${!password_var:-}"

--- a/plugin.yml
+++ b/plugin.yml
@@ -12,5 +12,8 @@ configuration:
       type: string
     password-env:
       type: string
+    retries:
+      type: number
+      default: 0
   required:
     - username


### PR DESCRIPTION
Adopt the retry function from ecr-buildkite-plugin with recent changes copied from https://github.com/buildkite-plugins/ecr-buildkite-plugin/pull/73

Fixes #46