### PR TITLE
Tester plugin

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,15 +1,14 @@
 steps:
   - label: ":shell: Tests"
     plugins:
-      docker-compose#v4.11.0:
-        run: tests
+      - plugin-tester#v1.0.0: ~
 
   - label: ":shell: Shellcheck"
     plugins:
-      shellcheck#v1.3.0:
-        files: hooks/**
+      - shellcheck#v1.3.0:
+          files: hooks/**
 
   - label: ":sparkles: Lint"
     plugins:
-      plugin-linter#v3.0.0:
-        id: docker-login
+      - plugin-linter#v3.1.0:
+          id: docker-login

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,0 @@
-version: '2'
-services:
-  tests:
-    image: buildkite/plugin-tester
-    volumes:
-      - ".:/plugin"

--- a/renovate.json
+++ b/renovate.json
@@ -1,10 +1,6 @@
 {
   "extends": [
-    "config:base"
-  ],
-  "docker-compose": {
-    "digest": {
-      "enabled": false
-    }
-  }
+    "config:base",
+    ":disableDependencyDashboard"
+  ]
 }


### PR DESCRIPTION
* replaces docker compose with the plugin tester
* updates the pipeline to use lists for plugins (to guarantee order)
* disables dependency dashboard (closes #57)