### PR TITLE
support password-env containing newlines

### DIFF
--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -27,7 +27,7 @@ function retry() {
   local stdin_value
 
   if [[ "$1" == "--with-stdin" ]]; then
-    read -sr stdin_value
+    stdin_value=$(cat)
     shift
   fi
 


### PR DESCRIPTION
bash `read` is meant to read up until a `\n` is encountered. This can break certain login flows.

Consider GCP (artifact registry). There are three methods for `docker login`: oauth2 token, JSON key, Base64-encoded JSON Key:

```yaml
      - docker-login#v2.1.0:
          username: oauth2accesstoken
          password-env: CLOUDSDK_AUTH_ACCESS_TOKEN
          server: https://us-docker.pkg.dev

      - docker-login#v2.1.0:
          username: _json_key
          password-env: SERVICE_ACCOUNT_KEY_JSON
          server: https://us-docker.pkg.dev

      - docker-login#v2.1.0:
          username: _json_key_base64
          password-env: SERVICE_ACCOUNT_KEY_JSON_BASE64
          server: https://us-docker.pkg.dev
```

Consider the `_json_key` method. The `SERVICE_ACCOUNT_KEY_JSON` file might be setup by a secrets handler in an environment hook like `SERVICE_ACCOUNT_KEY_JSON=$(vault get gsa_key)` or `$(cat /run/secrets/gsa)`. These files are typically JSON with line-breaks. This break the plugin because the `read -sr stdin_value` would only read the "`{\n`" from the json key file.

I believe the more flexible solution is to read stdin via `$(cat)`.

While I used GCP registries in my example there are likely other registries with auth methods using long, multiline strings that might benefit from this improvement too.

I will note that there is a workaround for the GCP JSON key file case. As long as the file is base64 encoded _without line breaks_ (`-w0` flag to `base64`) the `_json_key_base64` method will work without this change.